### PR TITLE
Minor changes for wx3

### DIFF
--- a/Python/RMarkdownEvents.py
+++ b/Python/RMarkdownEvents.py
@@ -8,17 +8,18 @@ from os.path import join, split, isdir, expanduser, realpath
 from os import walk
 from time import asctime, sleep
 
+quiet = 'TRUE' # or 'FALSE', since these are 'R' constants
 
 hardsettings = {'repo': "http://cran.stat.auckland.ac.nz/",
-                             'rendercommand': '''rmarkdown::render("{}")''',
-                             'renderallcommand': '''rmarkdown::render("{}", output_format="all")''',
-                             'renderslidycommand': '''rmarkdown::render("{}", output_format=slidy_presentation())''',
-                             'renderpdfcommand': '''rmarkdown::render("{}", output_format=pdf_document())''',
-                             'renderwordcommand': '''rmarkdown::render("{}", output_format=word_document())''',
-                             'renderhtmlcommand': '''rmarkdown::render("{}", output_format="html_document")''',
-                             'knit2mdcommand': '''knitr::knit("{}")''',
-                             'knit2htmlcommand': '''knitr::knit2html("{}")''',
-                             'knit2pdfcommand': '''knitr::knit2pdf("{}")'''}
+                             'rendercommand': '''rmarkdown::render(quiet={},"{}")''',
+                             'renderallcommand': '''rmarkdown::render(quiet={},"{}", output_format="all")''',
+                             'renderslidycommand': '''rmarkdown::render(quiet={},"{}", output_format=slidy_presentation())''',
+                             'renderpdfcommand': '''rmarkdown::render("quiet={},{}", output_format=pdf_document())''',
+                             'renderwordcommand': '''rmarkdown::render("quiet={},{}", output_format=word_document())''',
+                             'renderhtmlcommand': '''rmarkdown::render("quiet={},{}", output_format="html_document")''',
+                             'knit2mdcommand': '''knitr::knit(quiet={},"{}")''',
+                             'knit2htmlcommand': '''knitr::knit2html(quiet={},"{}")''',
+                             'knit2pdfcommand': '''knitr::knit2pdf(quiet={},"{}")'''}
 
 def OnProcess(self, event, whichcmd):
         self._mgr.GetPane("console").Show().Bottom().Layer(0).Row(0).Position(0)
@@ -29,6 +30,7 @@ def OnProcess(self, event, whichcmd):
                           '''install.packages('rmarkdown', repos="{0}")}};require(rmarkdown);'''.format(
                               hardsettings['repo']) +
                           hardsettings[whichcmd].format(
+                              quiet,
                               join(self.dirname, self.filename).replace('\\', '\\\\'))])
 
 def OnRenderNull(self, event):

--- a/Python/WriteR.pyw
+++ b/Python/WriteR.pyw
@@ -21,6 +21,7 @@ from os import walk
 from time import asctime, sleep
 
 print_option = False
+display_rscript_cmd = True
 
 # set up some ID tags
 ID_BUILD = wx.NewId()
@@ -156,8 +157,14 @@ class BashProcessThread(Thread):
         self.input_list = input_list
         printing(input_list)
         self.comp_thread = Popen(input_list, stdout=PIPE, stderr=STDOUT)
+
+        if display_rscript_cmd:
+           writelineFunc('\n'.join(input_list))
+           writelineFunc('\n\n')
+
         for line in self.comp_thread.stdout:
             writelineFunc(line)
+
         self.comp_thread.wait()
 
 class MyInterpretor(object):

--- a/Python/WriteR.pyw
+++ b/Python/WriteR.pyw
@@ -334,7 +334,7 @@ class MainWindow(wx.Frame):
         self.Bind(wx.EVT_MENU, self.OnSelectRenderPdf, self.ChooseRenderPdf) 
         self.ChooseRenderAll = renderMenu.Append(wx.ID_ANY, "Render into all specified formats", "Use the rmarkdown package and render function to create multiple output documents", wx.ITEM_RADIO)
         self.Bind(wx.EVT_MENU, self.OnSelectRenderAll, self.ChooseRenderAll) 
-        buildMenu.AppendMenu(-1, "Set render process to...", renderMenu) # Add the render Menu as a submenu to the build menu
+        buildMenu.Append(-1, "Set render process to...", renderMenu) # Add the render Menu as a submenu to the build menu
         for id, label, helpText, handler in \
                 [
                  (ID_KNIT2HTML, "Knit to html\tF6", "Knit the script to HTML", self.OnKnit2html),
@@ -372,7 +372,7 @@ class MainWindow(wx.Frame):
             else:
                 item = headingsMenu.Append(id, label, helpText)
                 self.Bind(wx.EVT_MENU, handler, item)
-        insertMenu.AppendMenu(-1, "Heading", headingsMenu)
+        insertMenu.Append(-1, "Heading", headingsMenu)
         menuBar.Append(insertMenu, "Insert")  # Add the Insert Menu to the MenuBar
 
         formatMenu = wx.Menu()
@@ -419,7 +419,7 @@ class MainWindow(wx.Frame):
             else:
                 item = symbolsMenu.Append(id, label, helpText)
                 self.Bind(wx.EVT_MENU, handler, item)
-        mathsMenu.AppendMenu(-1, "Symbols", symbolsMenu)
+        mathsMenu.Append(-1, "Symbols", symbolsMenu)
         structuresMenu = wx.Menu()
         for id, label, helpText, handler in \
                 [
@@ -438,7 +438,7 @@ class MainWindow(wx.Frame):
             else:
                 item = structuresMenu.Append(id, label, helpText)
                 self.Bind(wx.EVT_MENU, handler, item)
-        mathsMenu.AppendMenu(-1, "Structures", structuresMenu)# Add the structures Menu as a submenu to the main menu
+        mathsMenu.Append(-1, "Structures", structuresMenu)# Add the structures Menu as a submenu to the main menu
         GreekMenu = wx.Menu()
         for id, label, helpText, handler in \
                 [
@@ -473,7 +473,7 @@ class MainWindow(wx.Frame):
             else:
                 item = GreekMenu.Append(id, label, helpText)
                 self.Bind(wx.EVT_MENU, handler, item)
-        mathsMenu.AppendMenu(-1, "Greek letters", GreekMenu)
+        mathsMenu.Append(-1, "Greek letters", GreekMenu)
         menuBar.Append(mathsMenu, "Maths")  # Add the maths Menu to the MenuBar
 
         statsMenu = wx.Menu()
@@ -542,7 +542,7 @@ class MainWindow(wx.Frame):
 # Event handlers:
     # file menu events
     def OnOpen(self, event):
-        if self.askUserForFilename(style=wx.OPEN, **self.defaultFileDialogOptions()):
+        if self.askUserForFilename(style=wx.FD_OPEN, **self.defaultFileDialogOptions()):
             self.fileOpen(self.dirname, self.filename)
 
     def fileOpen(self, dirname, filename):
@@ -570,6 +570,7 @@ class MainWindow(wx.Frame):
 
 
     def OnExit(self, event):
+        self._mgr.UnInit()
         self.Close()  # Close the main window.
 
     def OnSafeExit(self, event):

--- a/Python/WriteR.pyw
+++ b/Python/WriteR.pyw
@@ -156,8 +156,9 @@ class BashProcessThread(Thread):
         self.input_list = input_list
         printing(input_list)
         self.comp_thread = Popen(input_list, stdout=PIPE, stderr=STDOUT)
-
-    #- def run(self):
+        for line in self.comp_thread.stdout:
+            writelineFunc(line)
+        self.comp_thread.wait()
 
 class MyInterpretor(object):
     def __init__(self, locals, rawin, stdin, stdout, stderr):


### PR DESCRIPTION
Minor changes to get WriteR to run on a mac using a newer wx version.

1. When building menus, apparently ".Append" is required instead of ".AppendMenu".
2. When opening files, "wx.FD_OPEN" is required instead of "wx.OPEN".
3. When closing the application, "self._mgr.UnInit()" is needed to avoid core dump.